### PR TITLE
Update Realm to 3.20.0 for Xcode 11 compatibility

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ target 'Sentinel' do
   pod 'secp256k1.swift', '~> 0.1.4'
   pod 'SwiftRichString', '~> 2.0.1'
   pod 'lottie-ios', '~> 2.5.0'
-  pod 'RealmSwift', '~> 3.7.1'
+  pod 'RealmSwift', '~> 3.20.0'
   pod 'Locksmith', '~> 4.0.0'
   pod 'QRCodeReader.swift', '~> 8.2.0'
   pod 'Starscream', '~> 3.0.5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,11 +22,11 @@ PODS:
     - PromiseKit/CorePromise
   - QRCodeReader.swift (8.2.0)
   - ReachabilitySwift (4.1.0)
-  - Realm (3.7.1):
-    - Realm/Headers (= 3.7.1)
-  - Realm/Headers (3.7.1)
-  - RealmSwift (3.7.1):
-    - Realm (= 3.7.1)
+  - Realm (3.20.0):
+    - Realm/Headers (= 3.20.0)
+  - Realm/Headers (3.20.0)
+  - RealmSwift (3.20.0):
+    - Realm (= 3.20.0)
   - Result (3.2.4)
   - secp256k1.swift (0.1.4)
   - Starscream (3.0.5)
@@ -41,7 +41,7 @@ DEPENDENCIES:
   - PromiseKit (~> 6.2.8)
   - QRCodeReader.swift (~> 8.2.0)
   - ReachabilitySwift (~> 4.1.0)
-  - RealmSwift (~> 3.7.1)
+  - RealmSwift (~> 3.20.0)
   - secp256k1.swift (~> 0.1.4)
   - Starscream (~> 3.0.5)
   - SwiftRichString (~> 2.0.1)
@@ -56,12 +56,13 @@ SPEC REPOS:
     - PromiseKit
     - QRCodeReader.swift
     - ReachabilitySwift
-    - Realm
-    - RealmSwift
     - Result
     - secp256k1.swift
     - Starscream
     - SwiftRichString
+  trunk:
+    - Realm
+    - RealmSwift
 
 EXTERNAL SOURCES:
   HDWalletKit:
@@ -83,13 +84,13 @@ SPEC CHECKSUMS:
   PromiseKit: 6788ce1a0ed5448b83d4aaf56b9fc49fb7647d32
   QRCodeReader.swift: 003eb32f18a5a675b936ec82ba0ff368cddbff45
   ReachabilitySwift: 6849231cd4e06559f3b9ef4a97a0a0f96d41e09f
-  Realm: 906be37d52f17f25484ac01643a7f26a9d3bfbd5
-  RealmSwift: 1c2b6bae3dc55bb87e080ffa96537d71442f6dce
+  Realm: 8b2ca5bc6479a91f379b6b42b5922e396cd5ba5a
+  RealmSwift: 1949ef26a279e1845bd51d591b9103adfcd121df
   Result: d2d07204ce72856f1fd9130bbe42c35a7b0fea10
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
   SwiftRichString: 3b29b5f2eb0eb244497532f2fd2ec26318eae584
 
-PODFILE CHECKSUM: b5336c3f57f88f5d0de222f1f060dbd9e976439f
+PODFILE CHECKSUM: 2b80b752d62fb9adc141f6233d1e71b6fbfc3bb3
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -47,7 +47,7 @@ DEPENDENCIES:
   - SwiftRichString (~> 2.0.1)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Alamofire
     - CryptoSwift
     - Locksmith
@@ -92,4 +92,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: b5336c3f57f88f5d0de222f1f060dbd9e976439f
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.9.1

--- a/Sentinel.xcodeproj/project.pbxproj
+++ b/Sentinel.xcodeproj/project.pbxproj
@@ -612,45 +612,16 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Sentinel/Pods-Sentinel-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/HDWalletKit/HDWalletKit.framework",
-				"${BUILT_PRODUCTS_DIR}/Locksmith/Locksmith.framework",
-				"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework",
-				"${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework",
-				"${BUILT_PRODUCTS_DIR}/QRCodeReader.swift/QRCodeReader.framework",
-				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/Reachability.framework",
-				"${BUILT_PRODUCTS_DIR}/Realm/Realm.framework",
-				"${BUILT_PRODUCTS_DIR}/RealmSwift/RealmSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
-				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftRichString/SwiftRichString.framework",
-				"${BUILT_PRODUCTS_DIR}/lottie-ios/Lottie.framework",
-				"${BUILT_PRODUCTS_DIR}/secp256k1.swift/secp256k1.framework",
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Sentinel/Pods-Sentinel-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptoSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/HDWalletKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Locksmith.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PromiseKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/QRCodeReader.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Realm.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RealmSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftRichString.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Lottie.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/secp256k1.framework",
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Sentinel/Pods-Sentinel-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sentinel/Pods-Sentinel-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Sentinel/Pods-Sentinel-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
Realm will throw a `RLMException` on startup when compiling with Xcode 11.x

```
RLMException, reason: 'Primary key property [...] does not exist on object [...]’
```

See [Realm issue 6163](https://github.com/realm/realm-cocoa/issues/6163) for details. Updating `RealmSwift` to 3.20.0 as suggested [here](https://stackoverflow.com/a/58040275) resolves this issue.

The updates to the project file were generated automatically by `pod install`